### PR TITLE
update smiles strings

### DIFF
--- a/guardowl/setup.py
+++ b/guardowl/setup.py
@@ -7,7 +7,7 @@ from rdkit import Chem
 from rdkit.Chem import AllChem
 
 
-def generate_molecule_from_smiles(smiles: str) -> Optional[Chem.Mol]:
+def generate_molecule_from_smiles(smiles: str) -> Chem.Mol:
     """
     Generates an RDKit molecule instance from a SMILES string with added hydrogens and a generated 3D conformer.
 
@@ -24,12 +24,12 @@ def generate_molecule_from_smiles(smiles: str) -> Optional[Chem.Mol]:
     molecule = Chem.MolFromSmiles(smiles)
     if molecule is None:
         log.error(f"Failed to generate molecule from SMILES: {smiles}")
-        return None
+        raise RuntimeError(f"Failed to generate molecule from SMILES: {smiles}")
 
     molecule = Chem.AddHs(molecule)
     if AllChem.EmbedMolecule(molecule) == -1:
         log.error(f"Failed to generate 3D conformer for molecule: {smiles}")
-        return None
+        raise RuntimeError(f"Failed to generate 3D conformer for molecule: {smiles}")
 
     return molecule
 

--- a/scripts/test_config.yaml
+++ b/scripts/test_config.yaml
@@ -29,10 +29,11 @@ tests:
   - protocol: "small_molecule_test"
     smiles:
       [
-        r"CCOc1ccc2nc(/N=C\c3ccccc3O)sc2c1",
-        r"Cn1cc(Cl)c(/C=N/O)n1",
-        r"S=c1cc(-c2ccc(Cl)cc2)ss1",
+        'CCOc1ccc2nc(/N=C\c3ccccc3O)sc2c1',
+        'Cn1cc(Cl)c(/C=N/O)n1',
+        'S=c1cc(-c2ccc(Cl)cc2)ss1',
       ]
+    names: ["mol1", "mol2", "mol3"]
     temperature: [300, 400, 500]
     nr_of_simulation_steps: 500
 


### PR DESCRIPTION
## Description

As outlined by @adambaskerville the yaml smiles string were using a `r"str'` convention, but this wasn't correctly parsed downstream. Changing this to `''` works as expected.

## Status
- [x] Ready to go